### PR TITLE
[Rust] Allow reflection verifier to start with custom root

### DIFF
--- a/rust/flatbuffers/src/verifier.rs
+++ b/rust/flatbuffers/src/verifier.rs
@@ -275,7 +275,7 @@ fn trace_elem<T>(res: Result<T>, index: usize, position: usize) -> Result<T> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct VerifierOptions<'a> {
+pub struct VerifierOptions {
     /// Maximum depth of nested tables allowed in a valid flatbuffer.
     pub max_depth: usize,
     /// Maximum number of tables allowed in a valid flatbuffer.
@@ -289,12 +289,9 @@ pub struct VerifierOptions<'a> {
     // probably want an option to ignore utf8 errors since strings come from c++
     // options to error un-recognized enums and unions? possible footgun.
     // Ignore nested flatbuffers, etc?
-
-    /// The name of the table to use as the root table instead of the schema root.
-    pub root_table_name: Option<&'a str>,
 }
 
-impl Default for VerifierOptions<'_> {
+impl Default for VerifierOptions {
     fn default() -> Self {
         Self {
             max_depth: 64,
@@ -302,7 +299,6 @@ impl Default for VerifierOptions<'_> {
             // size_ might do something different.
             max_apparent_size: 1 << 31,
             ignore_missing_null_terminator: false,
-            root_table_name: None,
         }
     }
 }
@@ -311,7 +307,7 @@ impl Default for VerifierOptions<'_> {
 #[derive(Debug)]
 pub struct Verifier<'opts, 'buf> {
     buffer: &'buf [u8],
-    opts: &'opts VerifierOptions<'opts>,
+    opts: &'opts VerifierOptions,
     depth: usize,
     num_tables: usize,
     apparent_size: usize,

--- a/rust/reflection/src/lib.rs
+++ b/rust/reflection/src/lib.rs
@@ -22,6 +22,7 @@ pub use vector_of_any::VectorOfAny;
 mod r#struct;
 pub use crate::r#struct::Struct;
 pub use crate::reflection_generated::reflection;
+pub use crate::reflection_verifier::verify_with_options;
 pub use crate::safe_buffer::SafeBuffer;
 
 use flatbuffers::{

--- a/rust/reflection/src/reflection_verifier.rs
+++ b/rust/reflection/src/reflection_verifier.rs
@@ -28,12 +28,13 @@ pub fn verify_with_options(
     schema: &Schema,
     opts: &VerifierOptions,
     buf_loc_to_obj_idx: &mut HashMap<usize, i32>,
+    root_table_name: Option<&str>,
 ) -> FlatbufferResult<()> {
     let mut verifier = Verifier::new(opts, buffer);
-    let root_table = match opts.root_table_name {
-        Some(root_table_name) => schema
+    let root_table = match root_table_name {
+        Some(name) => schema
             .objects()
-            .lookup_by_key(root_table_name, |o, k| o.key_compare_with_value(k)),
+            .lookup_by_key(name, |o, k| o.key_compare_with_value(k)),
         None => schema.root_table(),
     };
     if let Some(table_object) = root_table {

--- a/rust/reflection/src/safe_buffer.rs
+++ b/rust/reflection/src/safe_buffer.rs
@@ -49,7 +49,7 @@ impl<'a> SafeBuffer<'a> {
         opts: &VerifierOptions,
     ) -> FlatbufferResult<Self> {
         let mut buf_loc_to_obj_idx = HashMap::new();
-        verify_with_options(&buf, schema, opts, &mut buf_loc_to_obj_idx)?;
+        verify_with_options(&buf, schema, opts, &mut buf_loc_to_obj_idx, None)?;
         Ok(SafeBuffer {
             buf,
             schema,
@@ -141,7 +141,9 @@ impl<'a> SafeTable<'a> {
     pub fn get_field_string(&self, field_name: &str) -> FlatbufferResult<Option<&str>> {
         if let Some(field) = self.safe_buf.find_field_by_name(self.loc, field_name)? {
             // SAFETY: the buffer was verified during construction.
-            Ok(Some(unsafe { get_field_string(&Table::new(&self.safe_buf.buf, self.loc), &field) }))
+            Ok(Some(unsafe {
+                get_field_string(&Table::new(&self.safe_buf.buf, self.loc), &field)
+            }))
         } else {
             Err(FlatbufferError::FieldNotFound)
         }


### PR DESCRIPTION
The previous PR erroneously modified the `flatbuffers` crate instead of the `flatbuffers_reflection` crate. This PR reverts that and instead exposes the `flatbuffers_reflection` verification function with the appropriate change. This branch has been tested against the FlatBuffers extractor.